### PR TITLE
[IS-37] feat: Follow up prompt by user

### DIFF
--- a/components/EditDialog.vue
+++ b/components/EditDialog.vue
@@ -1,0 +1,24 @@
+<template>
+    <v-dialog v-model="isOpen" activator="parent" width="80%">
+        <v-card>
+            <v-card-title>{{ title }}</v-card-title>
+            <v-card-text>
+                <v-textarea v-model="value" variant="outlined"></v-textarea>
+                <CenterButton @click="onSave()">Save</CenterButton>
+            </v-card-text>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script setup>
+const props = defineProps(['title', 'modelValue']);
+const emit = defineEmits(['update:modelValue', 'save']);
+const value = ref(props.modelValue ?? "");
+const isOpen = ref(false);
+
+function onSave() {
+    isOpen.value = false;
+    emit('update:modelValue', value.value)
+    emit('save', value.value);
+}
+</script>

--- a/components/StatusMessage.vue
+++ b/components/StatusMessage.vue
@@ -1,0 +1,16 @@
+<template>
+    <div class="mt-3 text-center">
+        <p v-for="message in [...quiz.errors, quiz.status]" :class="statusColor(message)">
+            {{ message }}
+        </p>
+    </div>
+</template>
+
+<script setup>
+const quiz = useQuiz();
+const status = ref("");
+const statusColor = (message) =>
+    message === "Completed!" ? "text-success" :
+        message.includes("Error") ? "text-error" :
+            "black";
+</script>

--- a/components/markdown.vue
+++ b/components/markdown.vue
@@ -6,6 +6,9 @@
 import showdown from "showdown";
 const props = defineProps(['src']);
 const converter = new showdown.Converter();
-const html = ref("<p></p>");
-html.value = converter.makeHtml(props.src);
+const html = ref(converter.makeHtml(props.src));
+
+watch(() => props.src, () => {
+    html.value = converter.makeHtml(props.src);
+});
 </script>

--- a/composables/useQuiz.js
+++ b/composables/useQuiz.js
@@ -29,6 +29,7 @@ export const useQuiz = defineStore('quiz', {
 			diagram: "",
 			language: 'en-us',
 			mainpointsPrompt: '',
+			MCPrompt: '',
 		};
 	},
 	actions: {
@@ -61,9 +62,7 @@ export const useQuiz = defineStore('quiz', {
 			this.transcript = transcript;
 			this.language = language;
 			for (const task of selectedTask) {
-				if (task === 'mainpointsPrompt') {
-					this.mainpoints = '';
-				} else {
+				if (!task.includes('Prompt')) {
 					this[task] = [];
 				}
 			}
@@ -74,11 +73,11 @@ export const useQuiz = defineStore('quiz', {
 				let input = transcript;
 				try {
 					// Pre-process messages
-					if (task === 'mainpointsPrompt') {
-						input = this.messages.mainpoints.slice(0, 2);
+					if (task.includes('Prompt')) {
+						input = this.messages[task.split('Prompt')[0]].slice();
 						input.push({
 							role: 'user',
-							content: this.mainpointsPrompt + "\nRevised output:\n"
+							content: this[task] + "\nRevised output:\n"
 						});
 					}
 
@@ -103,9 +102,9 @@ export const useQuiz = defineStore('quiz', {
 					// Save messages for later tasks
 					this.messages[task] = res.msg;
 
-					if (task === 'mainpointsPrompt') {
-						this.messages.mainpoints[1] = res.msg[res.msg.length - 1];
-						task = 'mainpoints';
+					if (task.includes('Prompt')) {
+						task = task.split('Prompt')[0];
+						this.messages[task][this.messages[task].length - 1] = res.msg[res.msg.length - 1];
 					}
 
 					// Split cloze questions by '___' to render the inline blank

--- a/composables/useQuiz.js
+++ b/composables/useQuiz.js
@@ -3,13 +3,13 @@ import { defineStore, acceptHMRUpdate } from 'pinia';
 const tasks = [
 	'mainpoints',
 	'MC',
-	'TF',
-	'keywords',
-	'definition',
-	'cloze',
-	'clozeParagraph',
-	'SOP',
-	'diagram'
+	// 'TF',
+	// 'keywords',
+	// 'definition',
+	// 'cloze',
+	// 'clozeParagraph',
+	// 'SOP',
+	// 'diagram'
 ];
 
 export const useQuiz = defineStore('quiz', {
@@ -27,23 +27,33 @@ export const useQuiz = defineStore('quiz', {
 			clozeParagraph: {},
 			SOP: [],
 			diagram: "",
+			language: 'en-us',
 		};
 	},
 	actions: {
+		async regenerateTask(tasks) {
+			if (!tasks.includes('mainpoints')) {
+				this.messages.mainpoints[1].content = this.mainpoints;
+			}
+			this.generateQuiz(this.transcript, this.language, tasks);
+		},
+
 		// TODO: Retry failed requests
 		// since we rely on `this`, we cannot use an arrow function
-		async generateQuiz(transcript, language) {
+		async generateQuiz(transcript, language = this.language, selectedTask = []) {
 			// Prevent resending requests while generating quiz
 			if (this.status.includes('...')) return;
 			this.status = 'Loading...';
 			this.errors = [];
 
 			// Retry failed requests only if the input is the same
-			let selectedTask = [...tasks];
-			if (transcript == this.transcript && language == this.language) {
-				selectedTask = selectedTask.filter(task => this[task].length === 0);
-			} else {
-				this.messages = {};
+			if (selectedTask.length === 0) {
+				if (transcript == this.transcript && language == this.language) {
+					selectedTask = selectedTask.filter(task => this[task].length === 0);
+				} else {
+					selectedTask = [...tasks];
+					this.messages = {};
+				}
 			}
 
 			this.transcript = transcript;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,7 @@
     <v-textarea label="Insert transcript here" v-model="input" variant="outlined" rows="20" clearable
         class="mb-4" :maxlength="8000" counter persistent-counter 
         :readonly="quiz.status.includes('...')"></v-textarea>
-    <v-text-field label="Language" v-model="language" variant="outlined"></v-text-field>
+    <v-text-field label="Language" v-model="quiz.language" variant="outlined"></v-text-field>
     <CenterButton @click="generateQuiz">Generate Quiz</CenterButton>
     <div class="mt-3 text-center">
         <p v-for="message in [...quiz.errors, quiz.status]" :class="statusColor(message)">
@@ -15,7 +15,6 @@
 <script setup>
 const quiz = useQuiz();
 const input = ref(quiz.transcript);
-const language = ref("");
 const status = ref("");
 const statusColor = (message) => 
     message === "Completed!" ? "text-success" :
@@ -23,6 +22,6 @@ const statusColor = (message) =>
     "black";
 
 async function generateQuiz() {
-    await quiz.generateQuiz(input.value, language.value == "" ? "en-us" : language.value);
+    await quiz.generateQuiz(input.value);
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,11 +5,7 @@
         :readonly="quiz.status.includes('...')"></v-textarea>
     <v-text-field label="Language" v-model="quiz.language" variant="outlined"></v-text-field>
     <CenterButton @click="generateQuiz">Generate Quiz</CenterButton>
-    <div class="mt-3 text-center">
-        <p v-for="message in [...quiz.errors, quiz.status]" :class="statusColor(message)">
-            {{ message }}
-        </p>
-    </div>
+    <StatusMessage />
 </template>
 
 <script setup>

--- a/pages/mainpoints.vue
+++ b/pages/mainpoints.vue
@@ -1,6 +1,15 @@
 <template>
     <h2 class="mt-8 mb-4">What will you learn:</h2>
-    <Markdown :src="quiz.mainpoints"></Markdown>
+    <div v-if="isEditing">
+        <v-textarea v-model="quiz.mainpoints" label="Main Points" variant="outlined" rows="15"></v-textarea>
+        <CenterButton @click="isEditing = false; quiz.regenerateTask(['MC'])">Save
+        </CenterButton>
+        <p>When the "Save" button is clicked, the Multiple-choice and True/False questions will be re-generated.</p>
+    </div>
+    <div v-else>
+        <Markdown :src="quiz.mainpoints"></Markdown>
+        <CenterButton @click="isEditing = true">Edit</CenterButton>
+    </div>
 </template>
 
 <style>
@@ -11,4 +20,5 @@ li {
 
 <script setup>
 const quiz = useQuiz();
+const isEditing = ref(false);
 </script>

--- a/pages/mainpoints.vue
+++ b/pages/mainpoints.vue
@@ -3,11 +3,11 @@
     <div>
         <Markdown :src="quiz.mainpoints"></Markdown>
         <v-row justify="center">
-            <v-btn color="primary" class="ma-4">Edit
-                <EditDialog title="Edit mainpoints" v-model="quiz.mainpoints" @save="quiz.regenerateTask(['MC'])" />
+            <v-btn color="primary" class="ma-4">Edit Manually
+                <EditDialog title="Edit mainpoints" v-model="quiz.mainpoints" @save="quiz.regenerateTask(['mainpoints', 'MC'])" />
             </v-btn>
-            <v-btn color="primary" class="ma-4">Prompt
-                <EditDialog title="Prompt" v-model="quiz.mainpointsPrompt" @save="quiz.generateQuiz()" />
+            <v-btn color="primary" class="ma-4">Edit with Prompt
+                <EditDialog title="Prompt" v-model="quiz.mainpointsPrompt" @save="quiz.regenerateTask(['mainpointsPrompt', 'MC'])" />
             </v-btn>
         </v-row>
     </div>

--- a/pages/mainpoints.vue
+++ b/pages/mainpoints.vue
@@ -1,14 +1,15 @@
 <template>
     <h2 class="mt-8 mb-4">What will you learn:</h2>
-    <div v-if="isEditing">
-        <v-textarea v-model="quiz.mainpoints" label="Main Points" variant="outlined" rows="15"></v-textarea>
-        <CenterButton @click="isEditing = false; quiz.regenerateTask(['MC'])">Save
-        </CenterButton>
-        <p>When the "Save" button is clicked, the Multiple-choice and True/False questions will be re-generated.</p>
-    </div>
-    <div v-else>
+    <div>
         <Markdown :src="quiz.mainpoints"></Markdown>
-        <CenterButton @click="isEditing = true">Edit</CenterButton>
+        <v-row justify="center">
+            <v-btn color="primary" class="ma-4">Edit
+                <EditDialog title="Edit mainpoints" v-model="quiz.mainpoints" @save="quiz.regenerateTask(['MC'])" />
+            </v-btn>
+            <v-btn color="primary" class="ma-4">Prompt
+                <EditDialog title="Prompt" v-model="quiz.mainpointsPrompt" @save="quiz.generateQuiz()" />
+            </v-btn>
+        </v-row>
     </div>
 </template>
 
@@ -20,5 +21,4 @@ li {
 
 <script setup>
 const quiz = useQuiz();
-const isEditing = ref(false);
 </script>

--- a/pages/mainpoints.vue
+++ b/pages/mainpoints.vue
@@ -11,6 +11,7 @@
             </v-btn>
         </v-row>
     </div>
+    <StatusMessage />
 </template>
 
 <style>

--- a/pages/multiple-choice.vue
+++ b/pages/multiple-choice.vue
@@ -5,7 +5,13 @@
         </div>
         <MultipleChoiceOptions :q="q" :id="index" ref="options" />
     </div>
-    <CenterButton @click="reset">Try Again</CenterButton>
+    <v-row justify="center">
+        <v-btn color="primary" class="ma-4" @click="reset">Try Again</v-btn>
+        <v-btn color="primary" class="ma-4">Edit with Prompt
+            <EditDialog title="Prompt" v-model="quiz.MCPrompt" @save="quiz.regenerateTask(['MCPrompt'])" />
+        </v-btn>
+    </v-row>
+    <StatusMessage />
 </template>
 
 <script setup>

--- a/server/src/generateQuiz.js
+++ b/server/src/generateQuiz.js
@@ -65,7 +65,7 @@ async function extractContext(input, language = "en-us", task) {
 async function getQuestions(input, language = "en-us", task = "MC") {
     // Get questions
     let msg = input;
-    const callbackFunction = getFunctions(task);
+    const callbackFunction = getFunctions(task.split("Prompt")[0]);
 
     // Get prompt
     let req;
@@ -78,7 +78,7 @@ async function getQuestions(input, language = "en-us", task = "MC") {
     } else if (task === "clozeParagraph") {
         req = clozeParagraphPrompt(language);
     }
-    msg.push({ "role": "system", "content": req });
+    if (req) msg.push({ "role": "system", "content": req });
 
     const res = await getOpenAIResponse({
         messages: msg,
@@ -88,7 +88,7 @@ async function getQuestions(input, language = "en-us", task = "MC") {
 
     try {
         let result;
-        if (task === "MC" || task === "TF") {
+        if (task.includes("MC") || task === "TF") {
             result = processQuestions(res.function_call.arguments.result, task);
         } else if (task === "definition") {
             result = processDefinition(res.function_call.arguments.result);

--- a/server/src/postprocess.js
+++ b/server/src/postprocess.js
@@ -10,7 +10,7 @@ const wordBoundary = "[\\p{Katakana}\\p{Bopomofo}\\p{Hiragana}\\p{Han}\\p{Hangul
 export function processQuestions(questions, task) {
     let result = [];
     for (let q of questions) {
-        if (task === "MC") {
+        if (task.includes("MC")) {
             const { question, answer, options, difficulty } = q;
             // Shuffle options
             options.sort(() => Math.random() - 0.5);


### PR DESCRIPTION
Scope
=========
Quiz差异性报告：https://www.notion.so/Quiz-ae6d5e2fb7864c848c788d67a5e6e98a
- [x] User can add follow up prompt
- [ ] User can highlight text
- [x] User can edit mainpoints

Updates
=========

New Features
--------------------
### Main points
- Edit main points - 3d50389
- Regenerate quiz on mainpoints edited - 1b996e0
- Edit main points with prompt - fb411ce

### Multiple Choice Quiz
- Edit multiple-choice questions with prompt - 50716a8

### Other Quiz
- Remove other quiz - 1b996e0
    - True / False Quiz
    - Keyword Definition
    - Cloze / Cloze Paragraph Quiz
    - SOP Sorting Quiz
    - SOP Diagram Quiz

Project Maintenance
--------------------
### Components
- refactor: StatusMessage component - df2111f
- Add StatusMessage to input page - e194d86
- feat: EditDialog component - c3d9a75

TODO
========
- [ ] User can highlight text



